### PR TITLE
remove Courier New font override for non-OSX platforms

### DIFF
--- a/app/static/godoc.css
+++ b/app/static/godoc.css
@@ -24,7 +24,7 @@ a {
 	background: #FFD;
 }
 #code, pre, .lines {
-	font-family: Menlo, Courier New, monospace;
+	font-family: Menlo, monospace;
 	font-size: 11pt;
 }
 #code {


### PR DESCRIPTION
The Courier New setting overrides user's favorite font settings and make the playground look uglier on non-OSX platforms. Remove the override and let the user use their favorite font.