### PR TITLE
Added autofocus to textfield

### DIFF
--- a/app/goplay/edit.html
+++ b/app/goplay/edit.html
@@ -108,7 +108,7 @@
 			</div>
 		</div>
 		<div id="wrap">
-			<textarea itemprop="description" id="code" name="code" autocorrect="off" autocomplete="off" autocapitalize="off" spellcheck="false">{{printf "%s" .Snippet.Body}}</textarea>
+			<textarea itemprop="description" id="code" name="code" autocorrect="off" autocomplete="off" autocapitalize="off" spellcheck="false" autofocus>{{printf "%s" .Snippet.Body}}</textarea>
 		</div>
 		<div id="output"></div>
 		<img itemprop="image" src="/static/gopher.png" style="display:none">


### PR DESCRIPTION
This will place focus on the field that almost all users will immediately modify. In particular, you load the page and type CTRL+A to select the code, you select the entire page. I don't think this is the correct behavior.