### PR TITLE
playground: fix image tag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://play.golang.org/
 
 ```bash
 # build the image
-docker build -t playground .
+docker build -t golang/playground .
 ```
 
 ## Running


### PR DESCRIPTION
Fixes the image tag in the initial docker build command in the README.