### PR TITLE
Autofocus the text area on page load

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -132,7 +132,7 @@
 			<input type="button" value="About" id="aboutButton">
 		</div>
 		<div id="wrap">
-			<textarea itemprop="description" id="code" name="code" autocorrect="off" autocomplete="off" autocapitalize="off" spellcheck="false">{{printf "%s" .Snippet.Body}}</textarea>
+			<textarea autofocus="on" itemprop="description" id="code" name="code" autocorrect="off" autocomplete="off" autocapitalize="off" spellcheck="false">{{printf "%s" .Snippet.Body}}</textarea>
 		</div>
 		<div id="output"></div>
 		<img itemprop="image" src="/static/gopher.png" style="display:none">


### PR DESCRIPTION
Based on my own use case, the playground is probably often used for very quick one-off checks of language rules.

Autofocus on the `textarea` lowers friction in this case. Otherwise I rely on correctly hitting tab 7 times.