### PR TITLE
feat: If the container exists, no pull is performed to speed up program execution

### DIFF
--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -143,8 +143,10 @@ func main() {
 		log.Printf("Running in dev mode; container published to host at: http://localhost:8080/")
 		log.Printf("Run a binary with: curl -v --data-binary @/home/bradfitz/hello http://localhost:8080/run\n")
 	} else {
-		if out, err := exec.Command("docker", "pull", *container).CombinedOutput(); err != nil {
-			log.Fatalf("error pulling %s: %v, %s", *container, err, out)
+		if _, err := exec.Command("docker", "images", "-q", *container).CombinedOutput(); err != nil {
+			if out, err := exec.Command("docker", "pull", *container).CombinedOutput(); err != nil {
+				log.Fatalf("error pulling %s: %v, %s", *container, err, out)
+			}
 		}
 		log.Printf("Listening on %s", *listenAddr)
 	}


### PR DESCRIPTION
At present, the program will try to download the latest version of the execution image every time it is started. Since we will definitely execute the image parameters during execution, we can directly start the program after checking the existence of the image without repeating the download.