### PR TITLE
Fix test example

### DIFF
--- a/examples/test.txt
+++ b/examples/test.txt
@@ -9,7 +9,7 @@ import (
 // -1 if x is not present. The loop condition has a fault that
 // causes somes tests to fail. Change it to i >= 0 to see them pass.
 func LastIndex(list []int, x int) int {
-	for i := len(list) - 1; i > 0; i-- {
+	for i := len(list) - 1; i >= 0; i-- {
 		if list[i] == x {
 			return i
 		}


### PR DESCRIPTION
The original example fails:

```bash
=== RUN   TestLastIndex
    prog.go:34: LastIndex([1], 1) = -1, want 0
    prog.go:34: LastIndex([2 1], 2) = -1, want 0
    prog.go:34: LastIndex([3 1 2 2 1 1], 3) = -1, want 0
--- FAIL: TestLastIndex (0.00s)
FAIL

1 test failed.
```

So, having fixed it, and now running it again, will get the correct result:

```bash
=== RUN   TestLastIndex
--- PASS: TestLastIndex (0.00s)
PASS

All tests passed.
```