### PR TITLE
sandbox: remove unused err, lowercase err msg

### DIFF
--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -57,8 +57,7 @@ const (
 )
 
 var (
-	errTooMuchOutput = errors.New("Output too large")
-	errRunTimeout    = errors.New("timeout running program")
+	errTooMuchOutput = errors.New("output too large")
 )
 
 // containedStartMessage is the first thing written to stdout by the


### PR DESCRIPTION
- Remove unused `errRunTimeout`.
- Lowercase message for `errTooMuchOutput`.