### PR TITLE
playground: configure CORS in one place

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -27,12 +27,6 @@ type editData struct {
 }
 
 func (s *server) handleEdit(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	if r.Method == "OPTIONS" {
-		// This is likely a pre-flight CORS request.
-		return
-	}
-
 	// Redirect foo.play.golang.org to play.golang.org.
 	if strings.HasSuffix(r.Host, "."+hostname) {
 		http.Redirect(w, r, "https://"+hostname, http.StatusFound)

--- a/examples.go
+++ b/examples.go
@@ -28,7 +28,6 @@ type example struct {
 }
 
 func (h *examplesHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 	for _, e := range h.examples {
 		if e.Path == req.URL.Path {
 			http.ServeContent(w, req, e.Path, h.modtime, strings.NewReader(e.Content))

--- a/fmt.go
+++ b/fmt.go
@@ -21,11 +21,6 @@ type fmtResponse struct {
 }
 
 func (s *server) handleFmt(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	if r.Method == "OPTIONS" {
-		// This is likely a pre-flight CORS request.
-		return
-	}
 	w.Header().Set("Content-Type", "application/json")
 
 	fs, err := splitFiles([]byte(r.FormValue("body")))

--- a/fmt_test.go
+++ b/fmt_test.go
@@ -135,10 +135,6 @@ func TestHandleFmt(t *testing.T) {
 			if resp.StatusCode != 200 {
 				t.Fatalf("code = %v", resp.Status)
 			}
-			corsHeader := "Access-Control-Allow-Origin"
-			if got, want := resp.Header.Get(corsHeader), "*"; got != want {
-				t.Errorf("Header %q: got %q; want %q", corsHeader, got, want)
-			}
 			if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
 				t.Fatalf("Content-Type = %q; want application/json", ct)
 			}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.10
 	github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d
 	github.com/google/go-cmp v0.7.0
+	github.com/jub0bs/cors v0.12.1
 	go.opencensus.io v0.24.0
 	golang.org/x/build v0.0.0-20260206193512-474af8a99b39
 	golang.org/x/mod v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,8 @@ github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jub0bs/cors v0.12.1 h1:uEQHWpRMJ1A170tYy5ukd83ZwKt0Po/RK6SS7kAe+Tc=
+github.com/jub0bs/cors v0.12.1/go.mod h1:wlDBCHWBj/1rV242LHu1ylqLbZaPb2cmteuvZotyzug=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/sandbox.go
+++ b/sandbox.go
@@ -90,15 +90,9 @@ type response struct {
 // from the "body" form parameter or from the HTTP request body.
 // If there is no cached *response for the combination of cachePrefix and request.Body,
 // handler calls cmdFunc and in case of a nil error, stores the value of *response in the cache.
-// The handler returned supports Cross-Origin Resource Sharing (CORS) from any domain.
 func (s *server) commandHandler(cachePrefix string, cmdFunc func(context.Context, *request) (*response, error)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cachePrefix := cachePrefix // so we can modify it below
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		if r.Method == "OPTIONS" {
-			// This is likely a pre-flight CORS request.
-			return
-		}
 
 		var req request
 		// Until programs that depend on golang.org/x/tools/godoc/static/playground.js

--- a/share.go
+++ b/share.go
@@ -43,11 +43,6 @@ func (s *snippet) ID() string {
 }
 
 func (s *server) handleShare(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	if r.Method == "OPTIONS" {
-		// This is likely a pre-flight CORS request.
-		return
-	}
 	if r.Method != "POST" {
 		http.Error(w, "Requires POST", http.StatusMethodNotAllowed)
 		return

--- a/version.go
+++ b/version.go
@@ -12,8 +12,6 @@ import (
 )
 
 func (s *server) handleVersion(w http.ResponseWriter, req *http.Request) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-
 	tag := build.Default.ReleaseTags[len(build.Default.ReleaseTags)-1]
 	var maj, min int
 	if _, err := fmt.Sscanf(tag, "go%d.%d", &maj, &min); err != nil {


### PR DESCRIPTION
Several endpoints are configured for CORS, to allow anonymous access
from any origin. However, the relevant code is duplicated for all the
endpoints in question.

This CL adds github.com/jub0bs/cors as a dependency and moves all CORS
concerns to server initialization, thereby reducing code duplication.
It also augments the server's test suite with new cases.